### PR TITLE
Add retries for `xctrace` commands to avoid SIGSEV failures

### DIFF
--- a/src/main/kotlin/com/bromano/mobile/perf/utils/WithRetry.kt
+++ b/src/main/kotlin/com/bromano/mobile/perf/utils/WithRetry.kt
@@ -1,0 +1,38 @@
+package com.bromano.mobile.perf.utils
+
+/**
+ * Executes [block] and retries it when an exception is thrown, up to [maxAttempts] times.
+ *
+ * @param maxAttempts total number of attempts; must be at least 1.
+ * @param delayMillis sleep duration in milliseconds between retries.
+ * @param shouldRetry predicate that decides whether the caught [Throwable] should trigger another attempt.
+ * @param block operation to run with retry semantics.
+ * @throws Throwable the last error encountered when retries are exhausted or `shouldRetry` returns false.
+ */
+inline fun <T> withRetry(
+    maxAttempts: Int = 3,
+    delayMillis: Long = 0,
+    shouldRetry: (Throwable) -> Boolean = { true },
+    block: () -> T
+): T {
+    require(maxAttempts >= 1) { "maxAttempts must be at least 1" }
+
+    var lastError: Throwable? = null
+    repeat(maxAttempts) { attemptIndex ->
+        try {
+            return block()
+        } catch (error: Throwable) {
+            lastError = error
+            val isLastAttempt = attemptIndex == maxAttempts - 1
+            if (!shouldRetry(error) || isLastAttempt) {
+                throw error
+            }
+
+            if (delayMillis > 0) {
+                Thread.sleep(delayMillis)
+            }
+        }
+    }
+
+    throw lastError ?: IllegalStateException("withRetry failed without executing block")
+}

--- a/src/test/kotlin/com/bromano/mobile/perf/utils/WithRetryTest.kt
+++ b/src/test/kotlin/com/bromano/mobile/perf/utils/WithRetryTest.kt
@@ -1,0 +1,82 @@
+package com.bromano.mobile.perf.utils
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WithRetryTest {
+    @Test
+    fun executesBlockOnceWhenSuccessful() {
+        var invocationCount = 0
+
+        val result = withRetry(maxAttempts = 3) {
+            invocationCount++
+            "success"
+        }
+
+        assertEquals(1, invocationCount)
+        assertEquals("success", result)
+    }
+
+    @Test
+    fun retriesUntilSuccessWithinMaxAttempts() {
+        var attempts = 0
+
+        val value = withRetry(maxAttempts = 3) {
+            attempts++
+            if (attempts < 3) {
+                throw IllegalStateException("failure $attempts")
+            }
+            "recovered"
+        }
+
+        assertEquals(3, attempts)
+        assertEquals("recovered", value)
+    }
+
+    @Test
+    fun stopsRetryingWhenPredicateReturnsFalse() {
+        var attempts = 0
+
+        val error = assertFailsWith<IllegalArgumentException> {
+            withRetry(maxAttempts = 5, shouldRetry = { it !is IllegalArgumentException }) {
+                attempts++
+                throw IllegalArgumentException("do not retry")
+            }
+        }
+
+        assertEquals(1, attempts)
+        assertEquals("do not retry", error.message)
+    }
+
+    @Test
+    fun throwsLastErrorAfterExhaustingAttempts() {
+        var attempts = 0
+
+        val error = assertFailsWith<RuntimeException> {
+            withRetry(maxAttempts = 3) {
+                attempts++
+                throw RuntimeException("failure $attempts")
+            }
+        }
+
+        assertEquals(3, attempts)
+        assertEquals("failure 3", error.message)
+    }
+
+    @Test
+    fun requiresAtLeastOneAttempt() {
+        var executed = false
+
+        val error = assertFailsWith<IllegalArgumentException> {
+            withRetry(maxAttempts = 0) {
+                executed = true
+            }
+        }
+
+        assertTrue(error.message!!.contains("maxAttempts"))
+        assertFalse(executed)
+    }
+}


### PR DESCRIPTION
**Background**
`xctrace` can fail with transient SIGSEVs. We should defensively guard against this until `xctrace` is patched. 

**Changes**
* Implement a `withRetry` utility to support generic capabilities
* Wrap `xctrace` command invocations with retries
* Implement `ShellCommandException` exception sub-class to propagate exit code for retry logic

**Test Plan**
I ran `instruments-to-gecko` with corrupted `trace` and file and forced retries on exit code 10 since simulating SIGSEV is difficult.

```
 ✘ benjaminromano  ~/Dev/instruments-to-gecko   bromano/succint-retries ●  java -jar ./build/libs/instruments-to-gecko.jar --input ~/Dev/mobileperf-cli/artifacts/trace_out/instruments-2025-10-03-15-39.trace --output example.out
Exception in thread "main" com.bromano.instrumentsgecko.ShellCommandException: Command, `xctrace export --input /Users/benjaminromano/Dev/mobileperf-cli/artifacts/trace_out/instruments-2025-10-03-15-39.trace --toc`, failed with exit code 10: Export failed: Document Missing Template Error
	at com.bromano.instrumentsgecko.ShellUtils$Companion.run(ShellUtils.kt:61)
	at com.bromano.instrumentsgecko.ShellUtils$Companion.run(ShellUtils.kt:18)
	at com.bromano.instrumentsgecko.ShellUtils$Companion.run$default(ShellUtils.kt:10)
	at com.bromano.instrumentsgecko.InstrumentsParser.queryXCTraceTOC(InstrumentsParser.kt:389)
	at com.bromano.instrumentsgecko.InstrumentsParser.getInstrumentsSettings(InstrumentsParser.kt:171)
	at com.bromano.instrumentsgecko.GeckoCommand.run(GeckoCommand.kt:70)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:198)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:18)
	at com.github.ajalt.clikt.core.CliktCommand.parse(CliktCommand.kt:400)
	at com.github.ajalt.clikt.core.CliktCommand.parse$default(CliktCommand.kt:397)
	at com.github.ajalt.clikt.core.CliktCommand.main(CliktCommand.kt:415)
	at com.github.ajalt.clikt.core.CliktCommand.main(CliktCommand.kt:440)
	at com.bromano.instrumentsgecko.GeckoCommandKt.main(GeckoCommand.kt:17)
```
