### PR TITLE
Prevent xctrace export crashes on large traces

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   build-and-release:
     runs-on: macos-26
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - name: Checkout
@@ -62,8 +62,23 @@ jobs:
           TAG_NO_V="${RELEASE_VERSION#v}"
           echo "Building release version: $TAG_NO_V"
           ./gradlew --no-daemon --stacktrace --warning-mode=all \
-            -Dmperf.integration.ios.enabled=true \
             -PreleaseVersion="$TAG_NO_V" clean build shadowJar generateDocs
+
+      - name: Run iOS integration tests
+        run: |
+          for attempt in 1 2; do
+            if ./gradlew test --no-daemon --stacktrace \
+              -Dmperf.integration.ios.enabled=true \
+              --tests com.bromano.mobile.perf.integration.IosProfilerIntegrationTest \
+              --tests com.bromano.mobile.perf.gecko.InstrumentsConverterTest; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 2 ]; then
+              exit 1
+            fi
+            echo "::warning::Xcode failed the live integration run; resetting Simulators and retrying once"
+            xcrun simctl shutdown all || true
+          done
 
       - name: Verify generated documentation is current
         run: git diff --exit-code -- docs/cli.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-13
+
 ### Added
 
 - Added end-to-end Android emulator coverage for ad-hoc and Macrobenchmark Perfetto, Simpleperf, and ART method-trace collection. The standalone API 35 fixture uses Android Gradle Plugin 9.2.1, Macrobenchmark 1.4.1, and AndroidX Tracing 2.0.0-alpha09 without adding Android build dependencies to the CLI project.
@@ -35,7 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Changed Instruments conversion to export all required schemas once and overlap that export with table-of-contents inspection, removing a duplicate Time Profiler export and cutting measured conversion latency by 48.8% on the checked-in benchmark trace.
 - Changed configuration writes to use an atomic temporary-file replacement, CLI startup to close its HTTP client, and documentation generation to avoid creating or reading the user's `~/.mperf/config.yml`.
 - Changed the installer to resolve release assets through structured GitHub API JSON, accept prerelease versions, retry transient downloads, verify checksums before installation, and stage downloads in a temporary directory.
-- Changed the release workflow to require SemVer tags on `main`, run the complete build and iOS integration suite, verify generated docs and JAR metadata, publish prereleases correctly, and emit verified SHA-256 assets and GitHub build-provenance attestations.
+- Changed the release workflow to require SemVer tags on `main`, run the complete build and iOS integration suite with one bounded Simulator-reset retry, verify generated docs and JAR metadata, publish prereleases correctly, and emit verified SHA-256 assets and GitHub build-provenance attestations.
 - Updated all GitHub Actions to current immutable commit pins, including Checkout 7.0.0, Setup Java 5.5.0, Gradle Actions 6.2.0, setup-xcode 1.7.0, Android Emulator Runner 2.38.0, build provenance 4.1.1, and action-gh-release 3.0.1.
 - Updated the README and generated CLI reference for current platform requirements, Android profiling behavior, secure path handling, iOS Simulator integration, `--time-limit`, development commands, and the release process.
 
@@ -47,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Fixed transient Xcode 26 `xctrace` finalization failures leaving partial Instruments outputs and failing simulator collection; exit codes 1, 139, and 141 (`SIGPIPE`) now trigger one clean retry only when collection created a partial trace, while preflight and argument errors still fail immediately.
 - Fixed hosted Xcode 26 finalization stalls exhausting the bounded collection wait after creating a partial trace; deadline overruns retain timeout classification after termination, the previous process must be confirmed reaped before the guarded clean retry, and unreapable processes fail without starting an overlapping collection.
 - Fixed Xcode 26 instability while finalizing host-wide, multi-instrument Simulator traces by keeping the live Time Profiler launch capture focused on samples and validating Points of Interest in a separate Logging attach capture; the test also verifies the fixture markers through the Simulator unified log because Xcode's reliable host-wide fallback cannot include guest log events.
+- Fixed timed Instruments recordings using a two-minute process deadline regardless of the requested duration. Collection now allows the requested `--time-limit` plus a bounded three-minute Xcode startup and finalization grace period before terminating a stuck process.
 - Fixed Macrobenchmark failures being treated as successful collections and stale output files being selected when a run did not produce a new trace.
 - Fixed ART method tracing using the wall-clock flag before its supported API level and pulling traces before Android finished writing them.
 - Fixed Perfetto and Simpleperf sessions failing nondeterministically when profiler process startup took longer than a fixed delay.
@@ -55,6 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Fixed iOS simulator collection hangs caused by unreliable `xctrace --launch` behavior, ambiguous UUID-based device classification, display-name bundle lookup, and incomplete process-registration timing.
 - Fixed converted simulator profiles mixing unrelated host processes or resolving frames against another process's overlapping image addresses by preserving per-library PIDs and filtering converted output to the selected simulator app process. The unavoidable host-wide raw-trace fallback is now warned and documented explicitly.
 - Fixed Instruments parser failures on current Xcode XML layouts, XML declarations or leading output, and run numbers below one.
+- Fixed `xctrace export` crashes on large Instruments traces by writing XPath and table-of-contents XML to securely quoted temporary files instead of streaming large exports through stdout; partial files are cleared before retry and always removed afterward. Reported by @ldct in #9.
 - Fixed generated docs mutating user configuration and fixed configuration writes that could leave partially written YAML after interruption.
 - Fixed command-line splitting for escaped characters, empty quoted arguments, general whitespace, trailing escapes, and unterminated quotes.
 - Fixed output-directory creation for bare filenames, stale Instruments output reuse, unsupported Instruments instrumentation-test calls silently succeeding, and the main HTTP client leaking resources.
@@ -69,4 +73,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Made the release installer require a valid checksum asset and reject mismatches before replacing an installed JAR.
 - Pinned the Gradle distribution, profiler binaries, release artifacts, and third-party GitHub Actions to verified checksums or immutable revisions, and added GitHub artifact provenance attestations for published JARs.
 
-[Unreleased]: https://github.com/benjaminromano/mperf/compare/v1.0.5...HEAD
+[Unreleased]: https://github.com/benjaminromano/mperf/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/benjaminromano/mperf/compare/v1.0.5...v1.1.0

--- a/src/main/kotlin/com/bromano/mobile/perf/gecko/InstrumentsParser.kt
+++ b/src/main/kotlin/com/bromano/mobile/perf/gecko/InstrumentsParser.kt
@@ -1,5 +1,6 @@
 package com.bromano.mobile.perf.gecko
 
+import com.bromano.mobile.perf.utils.Shell
 import com.bromano.mobile.perf.utils.ShellCommandException
 import com.bromano.mobile.perf.utils.ShellExecutor
 import com.bromano.mobile.perf.utils.withRetry
@@ -10,6 +11,7 @@ import org.w3c.dom.NodeList
 import org.xml.sax.InputSource
 import java.io.StringReader
 import java.io.StringWriter
+import java.nio.file.Files
 import java.nio.file.Path
 import javax.xml.XMLConstants
 import javax.xml.parsers.DocumentBuilderFactory
@@ -504,43 +506,52 @@ object InstrumentsParser {
     private fun queryXCTrace(
         input: Path,
         xpath: String,
-    ): Document {
-        val xmlStr =
-            withRetry(
-                delayMillis = XCTRACE_RETRY_DELAY_MS,
-                shouldRetry = { (it as? ShellCommandException)?.exitCode == SIGSEV_EXIT_CODE },
-            ) {
-                ShellExecutor().runCommand(
-                    "xcrun xctrace export --input ${shellQuote(input.toString())} --xpath ${shellQuote(xpath)}",
-                    redirectOutput = ProcessBuilder.Redirect.PIPE,
-                    redirectError = ProcessBuilder.Redirect.PIPE,
-                    shell = true,
-                )
-            }
-
-        return processXCTraceOutput(xmlStr)
-    }
+    ): Document = processXCTraceOutput(exportXCTraceXml(input, "--xpath", xpath))
 
     /**
      * Get the Table of Contents
      *
      * Note: It doesn't seem possible to use `--xpath` to query the TOC
      */
-    private fun queryXCTraceTOC(input: Path): Document {
-        val xmlStr =
+    private fun queryXCTraceTOC(input: Path): Document = processXCTraceOutput(exportXCTraceXml(input, "--toc"))
+
+    internal fun exportXCTraceXml(
+        input: Path,
+        selector: String,
+        selectorValue: String? = null,
+        shell: Shell = ShellExecutor(),
+        temporaryFile: () -> Path = { Files.createTempFile("mperf-xctrace-export-", ".xml") },
+    ): String {
+        require(
+            (selector == "--toc" && selectorValue == null) ||
+                (selector == "--xpath" && selectorValue != null),
+        ) { "xctrace export requires --toc or --xpath with an expression" }
+
+        val output = temporaryFile()
+        return try {
             withRetry(
                 delayMillis = XCTRACE_RETRY_DELAY_MS,
                 shouldRetry = { (it as? ShellCommandException)?.exitCode == SIGSEV_EXIT_CODE },
             ) {
-                ShellExecutor().runCommand(
-                    "xcrun xctrace export --input ${shellQuote(input.toString())} --toc",
+                Files.deleteIfExists(output)
+                val command =
+                    buildList {
+                        addAll(listOf("xcrun", "xctrace", "export", "--input", input.toString(), selector))
+                        selectorValue?.let(::add)
+                        addAll(listOf("--output", output.toString()))
+                    }.joinToString(" ") { shellQuote(it) }
+                shell.runCommand(
+                    command,
                     redirectOutput = ProcessBuilder.Redirect.PIPE,
                     redirectError = ProcessBuilder.Redirect.PIPE,
                     shell = true,
                 )
             }
-
-        return processXCTraceOutput(xmlStr)
+            require(Files.isRegularFile(output)) { "xctrace did not create XML output at $output" }
+            Files.readString(output)
+        } finally {
+            Files.deleteIfExists(output)
+        }
     }
 
     internal fun processXCTraceOutput(xmlStr: String): Document {

--- a/src/main/kotlin/com/bromano/mobile/perf/utils/XcodeUtils.kt
+++ b/src/main/kotlin/com/bromano/mobile/perf/utils/XcodeUtils.kt
@@ -292,7 +292,7 @@ class XcodeUtils(
                 shell.startProcess("kill -INT ${process.pid()}")
                 shell.waitFor(process, 30, TimeUnit.SECONDS)
             } else {
-                shell.waitFor(process, 2, TimeUnit.MINUTES)
+                shell.waitFor(process, recordingCompletionTimeoutMillis(timeLimit), TimeUnit.MILLISECONDS)
             }
         if (!stoppedWithinDeadline) {
             process.destroy()
@@ -362,6 +362,31 @@ class XcodeUtils(
 
     private companion object {
         const val SIMULATOR_LIST_COMMAND = "xcrun simctl list devices available --json"
+        val XCTRACE_FINALIZATION_GRACE_MILLIS = TimeUnit.MINUTES.toMillis(3)
+        val XCTRACE_TIME_LIMIT = Regex("""^(\d+)(ms|s|m|h)$""")
+
+        fun recordingCompletionTimeoutMillis(timeLimit: String): Long {
+            val match =
+                XCTRACE_TIME_LIMIT.matchEntire(timeLimit.trim())
+                    ?: return XCTRACE_FINALIZATION_GRACE_MILLIS
+            val amount = match.groupValues[1].toLongOrNull() ?: return Long.MAX_VALUE
+            val unitMillis =
+                when (match.groupValues[2]) {
+                    "ms" -> 1L
+                    "s" -> TimeUnit.SECONDS.toMillis(1)
+                    "m" -> TimeUnit.MINUTES.toMillis(1)
+                    "h" -> TimeUnit.HOURS.toMillis(1)
+                    else -> error("Unsupported xctrace duration unit")
+                }
+            val maximumRecordingMillis = Long.MAX_VALUE - XCTRACE_FINALIZATION_GRACE_MILLIS
+            val recordingMillis =
+                if (amount > maximumRecordingMillis / unitMillis) {
+                    maximumRecordingMillis
+                } else {
+                    amount * unitMillis
+                }
+            return recordingMillis + XCTRACE_FINALIZATION_GRACE_MILLIS
+        }
     }
 
     private fun InputStream.forwardToStdout() {

--- a/src/test/kotlin/com/bromano/mobile/perf/gecko/InstrumentsParserXmlTest.kt
+++ b/src/test/kotlin/com/bromano/mobile/perf/gecko/InstrumentsParserXmlTest.kt
@@ -1,9 +1,17 @@
 package com.bromano.mobile.perf.gecko
 
+import com.bromano.mobile.perf.utils.FakeShell
+import com.bromano.mobile.perf.utils.ShellCommandException
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
 import org.xml.sax.SAXParseException
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.writeText
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class InstrumentsParserXmlTest {
     @Test
@@ -41,5 +49,89 @@ class InstrumentsParserXmlTest {
                 """.trimIndent(),
             )
         }
+    }
+
+    @Test
+    fun `exports xctrace XML through a temporary file`(
+        @TempDir tempDir: Path,
+    ) {
+        val output = tempDir.resolve("export with spaces.xml")
+        val shell = FakeShell()
+        shell.runCommandHandler = { command, _, _, redirectOutput, redirectError ->
+            assertTrue(command.contains("'--output' '$output'"))
+            assertTrue(command.contains("'--input' '/tmp/input trace.trace'"))
+            assertTrue(command.contains("'--toc'"))
+            assertEquals(ProcessBuilder.Redirect.PIPE, redirectOutput)
+            assertEquals(ProcessBuilder.Redirect.PIPE, redirectError)
+            assertFalse(output.exists(), "stale temporary output should be removed before export")
+            output.writeText("<trace-toc/>")
+            "xctrace diagnostic output"
+        }
+
+        val xml =
+            InstrumentsParser.exportXCTraceXml(
+                Path.of("/tmp/input trace.trace"),
+                "--toc",
+                shell = shell,
+                temporaryFile = { output },
+            )
+
+        assertEquals("<trace-toc/>", xml)
+        assertFalse(output.exists(), "temporary export should be removed after it is read")
+    }
+
+    @Test
+    fun `removes partial xctrace output before retrying a segfault`(
+        @TempDir tempDir: Path,
+    ) {
+        val output = tempDir.resolve("export.xml")
+        val shell = FakeShell()
+        var attempts = 0
+        shell.runCommandHandler = { command, _, _, _, _ ->
+            attempts++
+            assertFalse(output.exists(), "partial output should be removed before attempt $attempts")
+            if (attempts == 1) {
+                output.writeText("partial")
+                throw ShellCommandException(command, 139, "segmentation fault")
+            }
+            output.writeText("<trace-query-result/>")
+            ""
+        }
+
+        val xml =
+            InstrumentsParser.exportXCTraceXml(
+                Path.of("/tmp/input.trace"),
+                "--xpath",
+                "/trace-toc/run[1]",
+                shell = shell,
+                temporaryFile = { output },
+            )
+
+        assertEquals(2, attempts)
+        assertEquals("<trace-query-result/>", xml)
+        assertFalse(output.exists())
+    }
+
+    @Test
+    fun `removes partial xctrace output after a terminal failure`(
+        @TempDir tempDir: Path,
+    ) {
+        val output = tempDir.resolve("failed-export.xml")
+        val shell = FakeShell()
+        shell.runCommandHandler = { _, _, _, _, _ ->
+            output.writeText("partial")
+            throw IllegalStateException("xctrace failed")
+        }
+
+        assertThrows<IllegalStateException> {
+            InstrumentsParser.exportXCTraceXml(
+                Path.of("/tmp/input.trace"),
+                "--toc",
+                shell = shell,
+                temporaryFile = { output },
+            )
+        }
+
+        assertFalse(output.exists(), "partial output should be removed after a terminal failure")
     }
 }

--- a/src/test/kotlin/com/bromano/mobile/perf/utils/XcodeUtilsTest.kt
+++ b/src/test/kotlin/com/bromano/mobile/perf/utils/XcodeUtilsTest.kt
@@ -235,6 +235,34 @@ class XcodeUtilsTest {
     }
 
     @Test
+    fun `record deadline includes requested duration and finalization grace`() {
+        var waitTimeout: Long? = null
+        var waitUnit: TimeUnit? = null
+        val simulatorShell =
+            object : FakeShell() {
+                override fun waitFor(
+                    process: Process,
+                    timeout: Long,
+                    unit: TimeUnit,
+                ): Boolean {
+                    waitTimeout = timeout
+                    waitUnit = unit
+                    return true
+                }
+            }
+        val simulatorId = "12345678-1234-1234-1234-123456789012"
+        simulatorShell.runCommandResponses["xcrun simctl list devices available --json"] = simulatorJson()
+        simulatorShell.runCommandResponses["xcrun simctl spawn '$simulatorId' launchctl list"] =
+            "123\t0\tUIKitApplication:com.example.app[abc]"
+        val simulatorUtils = XcodeUtils(simulatorId, simulatorShell, processStarter = { RecordingProcess() })
+
+        simulatorUtils.record("Time Profiler", emptyList(), "com.example.app", "/tmp/output.trace", "2m")
+
+        assertEquals(TimeUnit.MINUTES.toMillis(5), waitTimeout)
+        assertEquals(TimeUnit.MILLISECONDS, waitUnit)
+    }
+
+    @Test
     fun `record reports non-retryable failure when timed-out process cannot be reaped`() {
         val waitResults = ArrayDeque(listOf(false, false, false))
         val simulatorShell =


### PR DESCRIPTION
## Summary

- carry the file-backed `xctrace export` approach from #9 forward onto the current parser for both XPath and table-of-contents XML
- quote all export arguments, clear partial files before retrying exit 139, and always remove temporary output
- add regression tests for file-backed export, cleanup after success/retry/terminal failure, and segfault recovery
- make timed Instruments collection honor the requested recording duration plus bounded Xcode startup/finalization grace instead of applying a fixed two-minute process deadline
- keep release builds fail-fast while giving the isolated live iOS step one bounded Simulator-reset retry
- record the fixes and release infrastructure update in the `1.1.0` changelog

Thanks to @ldct for reporting the large-trace crash and proposing the original `--output` solution in #9.

## Validation

- `./gradlew clean build shadowJar jmhClasses generateDocs --no-daemon --stacktrace --warning-mode=all`
- focused Instruments parser, converter, profiler, and Xcode utility tests with forced rerun
- checked-in Instruments trace conversion through the new file-backed export path
- `scripts/test-install.sh`
- `git diff --exit-code -- docs/cli.md`
- release workflow YAML parse
- Instruments conversion JMH: 1,914.122 ms/op average (no regression from the optimized baseline)
- hosted Linux and Android gates passed on the prior reviewed head; final exact-head matrix pending after correcting the iOS deadline exposed by CI
